### PR TITLE
fix(GAT-8183): Remove geoname examples from coverage.spatial schema documentation

### DIFF
--- a/docs/GWDM/2.0.form.json
+++ b/docs/GWDM/2.0.form.json
@@ -320,10 +320,13 @@
             {
                   "required": false,
                   "title": "Geographic Coverage",
-                  "description": "The geographical area covered by the dataset. It is recommended that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/ or https://what3words.com/daring.lion.race.",
+                  "description": "The geographical area covered by the dataset.",
                   "guidance": "- The geographical area covered by the dataset.\\n- Please provide a valid location.\\n- For locations in the UK, this location should conform to [ONS standards](https://geoportal.statistics.gov.uk/datasets/208d9884575647c29f0dd5a1184e711a/about).\\n- For locations in other countries we use [ISO 3166-1 & ISO 3166-2](https://github.com/HDRUK/reference-codes).",
                   "examples": [
-                        "https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html"
+                        "England",
+                        "East Ayrshire",
+                        "Ardoyne",
+                        "Powys"
                   ],
                   "is_list": false,
                   "is_optional": true,

--- a/docs/GWDM/2.0.md
+++ b/docs/GWDM/2.0.md
@@ -310,7 +310,7 @@ This information includes attributes for geographical and temporal coverage, coh
 
 ### spatial
 
-The geographical area covered by the dataset. It is recommended that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/ or https://what3words.com/daring.lion.race.
+The geographical area covered by the dataset.
         
 | title               | guidance                                                                                                                                                                                                                                                                                                                                                                    | is_list   | required   | type                                                                                                      |
 |:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|:-----------|:----------------------------------------------------------------------------------------------------------|
@@ -318,7 +318,10 @@ The geographical area covered by the dataset. It is recommended that links are t
 
 Examples: 
 
-   * https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html
+   * England
+   * East Ayrshire
+   * Ardoyne
+   * Powys
 
 
 ### pathway

--- a/docs/GWDM/2.0.structure.json
+++ b/docs/GWDM/2.0.structure.json
@@ -411,10 +411,13 @@
                         "name": "spatial",
                         "required": false,
                         "title": "Geographic Coverage",
-                        "description": "The geographical area covered by the dataset. It is recommended that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/ or https://what3words.com/daring.lion.race.",
+                        "description": "The geographical area covered by the dataset.",
                         "guidance": "The geographical area covered by the dataset.- Please provide a valid location.- For locations in the UK, this location should conform to ONS standards.- For locations in other countries we use ISO 3166-1 & ISO 3166-2.",
                         "examples": [
-                              "https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html"
+                              "England",
+                              "East Ayrshire",
+                              "Ardoyne",
+                              "Powys"
                         ],
                         "type": [
                               "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",

--- a/docs/HDRUK/4.0.0.form.json
+++ b/docs/HDRUK/4.0.0.form.json
@@ -377,8 +377,10 @@
                   "description": "The geographical area covered by the dataset. It is recommended that links are to entries in one of the recommended standards:\\n- For locations in the UK: [ONS standards](https://geoportal.statistics.gov.uk/datasets/208d9884575647c29f0dd5a1184e711a/about)\\n- For locations in other countries: [ISO 3166-1 & ISO 3166-2](https://github.com/HDRUK/reference-codes)",
                   "guidance": "- The geographical area covered by the dataset.\\n- Please provide a valid location.\\n- For locations in the UK, this location should conform to [ONS standards](https://geoportal.statistics.gov.uk/datasets/208d9884575647c29f0dd5a1184e711a/about).\\n- For locations in other countries we use [ISO 3166-1 & ISO 3166-2](https://github.com/HDRUK/reference-codes).",
                   "examples": [
-                        "United Kingdom",
-                        "https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html"
+                        "England",
+                        "East Ayrshire",
+                        "Ardoyne",
+                        "Powys"
                   ],
                   "is_list": false,
                   "is_optional": false,

--- a/docs/HDRUK/4.0.0.md
+++ b/docs/HDRUK/4.0.0.md
@@ -337,8 +337,10 @@ The geographical area covered by the dataset. It is recommended that links are t
 
 Examples: 
 
-   * United Kingdom
-  * https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html
+   * England
+  * East Ayrshire
+  * Ardoyne
+  * Powys
 
 
 ### typicalAgeRangeMin

--- a/docs/HDRUK/4.0.0.structure.json
+++ b/docs/HDRUK/4.0.0.structure.json
@@ -438,8 +438,10 @@
                         "description": "The geographical area covered by the dataset. It is recommended that links are to entries in one of the recommended standards:- For locations in the UK: ONS standards- For locations in other countries: ISO 3166-1 & ISO 3166-2",
                         "guidance": "The geographical area covered by the dataset.- Please provide a valid location.- For locations in the UK, this location should conform to ONS standards.- For locations in other countries we use ISO 3166-1 & ISO 3166-2.",
                         "examples": [
-                              "United Kingdom",
-                              "https://www.geonames.org/2635167/united-kingdom-of-great-britain-and-northern-ireland.html"
+                              "England",
+                              "East Ayrshire",
+                              "Ardoyne",
+                              "Powys"
                         ],
                         "type": [
                               "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",


### PR DESCRIPTION
GWDM and HDR UK schema entries for coverage.spatial had references to the geonames website. This is no longer accepted data (URLs) because it then doesn't conform to the structure needed to be mapped for the "geographical coverage" filter on the Dataset & BioSample search UI. Removing references to geonames in documentation as first step in cleanup for that metadata field.